### PR TITLE
meson: remove unused import

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Maintainer: Clement Lefebvre <root@linuxmint.com>
 Build-Depends:
  debhelper-compat (= 13),
  meson,
- pkgconf,
 Standards-Version: 4.6.1
 Homepage: https://github.com/linuxmint/xapp-symbolic-icons
 

--- a/meson.build
+++ b/meson.build
@@ -5,8 +5,4 @@ project(
   meson_version : '>=0.56.0'
 )
 
-gnome = import('gnome')
-pkg = import('pkgconfig')
-i18n = import('i18n')
-
 subdir('icons')


### PR DESCRIPTION
I didn't find any function using them in meson.build (including the one in icons)