### PR TITLE
Redesign user-desktop

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -95,6 +95,12 @@ Source: https://github.com/ubuntu/yaru
 Comment: Derived from the Yaru icon theme; icons may include modifications.
 
 
+Files: icons/symbolic/xsi-user-desktop-symbolic.svg
+Copyright:
+ © xapp-symbolic-icons
+License: LGPL-3
+
+
 Files: icons/symbolic/*
 Copyright:
  © GNOME Project

--- a/icons/symbolic/xsi-user-desktop-symbolic.svg
+++ b/icons/symbolic/xsi-user-desktop-symbolic.svg
@@ -1,7 +1,73 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg height="16px" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg">
-    <g fill="#2e3436">
-        <path d="m 1 4 v 1 h 8 v -1 z m 0 0"/>
-        <path d="m 3 1 c -1.644531 0 -3 1.355469 -3 3 v 8 c 0 1.644531 1.355469 3 3 3 h 10 c 1.644531 0 3 -1.355469 3 -3 v -6 c 0 -1.644531 -1.355469 -3 -3 -3 h -3.585938 l -1.707031 -1.707031 c -0.1875 -0.1875 -0.441406 -0.292969 -0.707031 -0.292969 z m 0 2 h 3.585938 l 1.707031 1.707031 c 0.1875 0.1875 0.441406 0.292969 0.707031 0.292969 h 4 c 0.5625 0 1 0.4375 1 1 v 6 c 0 0.566406 -0.4375 1 -1 1 h -10 c -0.5625 0 -1 -0.433594 -1 -1 v -8 c 0 -0.5625 0.4375 -1 1 -1 z m 0 0"/>
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16px"
+   viewBox="0 0 16 16"
+   width="16px"
+   version="1.1"
+   id="svg382"
+   sodipodi:docname="xsi-user-desktop-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs386">
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect1376"
+       is_visible="true"
+       lpeversion="1"
+       nodesatellites_param="F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1"
+       unit="px"
+       method="auto"
+       mode="F"
+       radius="0"
+       chamfer_steps="1"
+       flexible="false"
+       use_knot_distance="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
+  </defs>
+  <sodipodi:namedview
+     id="namedview384"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="45.387417"
+     inkscape:cx="12.536514"
+     inkscape:cy="10.619683"
+     inkscape:window-width="2560"
+     inkscape:window-height="1348"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1256">
+    <inkscape:grid
+       type="xygrid"
+       id="grid6374" />
+  </sodipodi:namedview>
+  <g
+     id="g1256"
+     transform="matrix(0.875,0,0,0.875,1,1)">
+    <path
+       d="m 2,11 h 12 v 2 H 2 Z"
+       fill="#2e3436"
+       id="path787"
+       inkscape:path-effect="#path-effect1376"
+       inkscape:original-d="m 2,11 h 12 v 2 H 2 Z m 0,0"
+       style="fill:#bebebe;fill-opacity:0.443137" />
+    <path
+       d="M 3,0.99999995 C 1.355469,0.99999995 0,2.355469 0,4 v 8 c 0,1.644531 1.355469,3 3,3 h 10 c 1.644531,0 3,-1.355469 3,-3 V 4 C 16,2.355469 14.644531,0.99999995 13,0.99999995 Z M 3,3 h 10 c 0.554688,0 1,0.445312 1,1 v 8 c 0,0.554688 -0.5,1 -1,1 H 3 C 2.429688,13 2,12.570312 2,12 V 4 C 2,3.445312 2.445312,3 3,3 Z"
+       fill="#2e3436"
+       id="path2"
+       sodipodi:nodetypes="ssssssssssssssssss" />
+  </g>
 </svg>


### PR DESCRIPTION
user-desktop currently looks like a folder..

<img width="249" height="399" alt="image" src="https://github.com/user-attachments/assets/f73a66fb-982e-4b68-8f7f-1b0feec517f0" />

in Mint-Y it previously did not:

<img width="174" height="128" alt="image" src="https://github.com/user-attachments/assets/b4f92072-3a1f-4cf0-8a7b-0af28f450bf9" />

This PR redesigns this icon to make it look like a desktop, with a panel.

<img width="200" height="169" alt="image" src="https://github.com/user-attachments/assets/c6b8b10d-84db-4ae5-8396-68b71fd358ba" />

